### PR TITLE
BACKLOG-764 Fix initial watch deployment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = env => {
     if (env.deploy) {
         config.plugins.push(
             new WebpackShellPluginNext({
-                onDoneWatch: {
+                onAfterDone: {
                     scripts: ['yarn jahia-deploy pack']
                 }
             })


### PR DESCRIPTION
We are using a different webpack event to make sure we deploy after the whole project has been properly built.
